### PR TITLE
Removed venv statements from images

### DIFF
--- a/demos/01_license_plate/infra/Containerfile_cpu
+++ b/demos/01_license_plate/infra/Containerfile_cpu
@@ -2,10 +2,9 @@ FROM registry.access.redhat.com/ubi8/python-38
 
 WORKDIR /opt/app-root/src
 
-RUN python3 -m venv /tmp/.venv
-RUN . /tmp/.venv/bin/activate && python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip
 
-RUN . /tmp/.venv/bin/activate && pip install -r https://raw.githubusercontent.com/sa-mw-dach/dev_demos/main/external/licence-plate-workshop/requirements.txt
-RUN . /tmp/.venv/bin/activate && pip install requests
+RUN pip install -r https://raw.githubusercontent.com/sa-mw-dach/dev_demos/main/external/licence-plate-workshop/requirements.txt
+RUN pip install requests
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/demos/01_license_plate/infra/Containerfile_cpu_air-gapped
+++ b/demos/01_license_plate/infra/Containerfile_cpu_air-gapped
@@ -2,11 +2,10 @@ FROM registry.access.redhat.com/ubi8/python-38
 
 WORKDIR /opt/app-root/src
 
-RUN python3 -m venv /tmp/.venv
-RUN . /tmp/.venv/bin/activate && python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip
 
 RUN git clone https://github.com/sa-mw-dach/dev_demos.git
-RUN . /tmp/.venv/bin/activate && pip install -r dev_demos/external/licence-plate-workshop/requirements.txt
-RUN . /tmp/.venv/bin/activate && pip install requests
+RUN pip install -r dev_demos/external/licence-plate-workshop/requirements.txt
+RUN pip install requests
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/demos/01_license_plate/infra/Containerfile_gpu
+++ b/demos/01_license_plate/infra/Containerfile_gpu
@@ -7,10 +7,9 @@ RUN dnf -y install git
 RUN mkdir -p /opt/app-root/src 
 WORKDIR /opt/app-root/src
 
-RUN python3 -m venv /tmp/.venv
-RUN . /tmp/.venv/bin/activate && python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip
 
-RUN . /tmp/.venv/bin/activate && pip install -r https://raw.githubusercontent.com/sa-mw-dach/dev_demos/main/external/licence-plate-workshop/requirements.txt
-RUN . /tmp/.venv/bin/activate && pip install requests
+RUN pip install -r https://raw.githubusercontent.com/sa-mw-dach/dev_demos/main/external/licence-plate-workshop/requirements.txt
+RUN pip install requests
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/demos/01_license_plate/infra/Containerfile_gpu_air-gapped
+++ b/demos/01_license_plate/infra/Containerfile_gpu_air-gapped
@@ -7,11 +7,10 @@ RUN dnf -y install git
 RUN mkdir -p /opt/app-root/src 
 WORKDIR /opt/app-root/src
 
-RUN python3 -m venv /tmp/.venv
-RUN . /tmp/.venv/bin/activate && python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip
 
 RUN git clone https://github.com/sa-mw-dach/dev_demos.git
-RUN . /tmp/.venv/bin/activate && pip install -r dev_demos/external/licence-plate-workshop/requirements.txt
-RUN . /tmp/.venv/bin/activate && pip install requests
+RUN pip install -r dev_demos/external/licence-plate-workshop/requirements.txt
+RUN pip install requests
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/demos/01_license_plate/infra/workspace_ai_cpu.yml
+++ b/demos/01_license_plate/infra/workspace_ai_cpu.yml
@@ -44,11 +44,11 @@ commands:
     actions:
       - type: exec
         component: python
-        command: '. /tmp/.venv/bin/activate && python demos/01_license_plate/test_ai_model.py'
+        command: 'python demos/01_license_plate/test_ai_model.py'
         workdir: '${CHE_PROJECTS_ROOT}/dev_demos'
   - name: 01_license_plate__3 Test GPU computation
     actions:
       - type: exec
         component: python
-        command: '. /tmp/.venv/bin/activate && python demos/01_license_plate/test_gpu.py'
+        command: 'python demos/01_license_plate/test_gpu.py'
         workdir: '${CHE_PROJECTS_ROOT}/dev_demos'

--- a/demos/01_license_plate/infra/workspace_ai_cpu_air-gapped.yml
+++ b/demos/01_license_plate/infra/workspace_ai_cpu_air-gapped.yml
@@ -37,9 +37,9 @@ commands:
     actions:
       - type: exec
         component: python
-        command: '. /tmp/.venv/bin/activate && python dev_demos/demos/01_license_plate/test_ai_model.py'
+        command: 'python dev_demos/demos/01_license_plate/test_ai_model.py'
   - name: 01_license_plate__3 Test GPU computation
     actions:
       - type: exec
         component: python
-        command: '. /tmp/.venv/bin/activate && python dev_demos/demos/01_license_plate/test_gpu.py'
+        command: 'python dev_demos/demos/01_license_plate/test_gpu.py'

--- a/demos/01_license_plate/infra/workspace_ai_gpu.yml
+++ b/demos/01_license_plate/infra/workspace_ai_gpu.yml
@@ -51,11 +51,11 @@ commands:
     actions:
       - type: exec
         component: python/python
-        command: '. /tmp/.venv/bin/activate && python demos/01_license_plate/test_ai_model.py'
+        command: 'python demos/01_license_plate/test_ai_model.py'
         workdir: '${CHE_PROJECTS_ROOT}/dev_demos'
   - name: 01_license_plate__3 Test GPU computation
     actions:
       - type: exec
         component: python/python
-        command: '. /tmp/.venv/bin/activate && python demos/01_license_plate/test_gpu.py'
+        command: 'python demos/01_license_plate/test_gpu.py'
         workdir: '${CHE_PROJECTS_ROOT}/dev_demos'

--- a/demos/01_license_plate/infra/workspace_ai_gpu_air-gapped.yml
+++ b/demos/01_license_plate/infra/workspace_ai_gpu_air-gapped.yml
@@ -44,9 +44,9 @@ commands:
     actions:
       - type: exec
         component: python/python
-        command: '. /tmp/.venv/bin/activate && python dev_demos/demos/01_license_plate/test_ai_model.py'
+        command: 'python dev_demos/demos/01_license_plate/test_ai_model.py'
   - name: 01_license_plate__3 Test GPU computation
     actions:
       - type: exec
         component: python/python
-        command: '. /tmp/.venv/bin/activate && python dev_demos/demos/01_license_plate/test_gpu.py'
+        command: 'python dev_demos/demos/01_license_plate/test_gpu.py'


### PR DESCRIPTION
The current container images work with `venv`, a Python virtual environment tool. `venv` is great for working within multiple dependency stacks. However, working in containerized environments means managing dependency stacks through container images, which renders `venv` redundant.

I propose removing `venv` statements from container images for simplicity and slightly optimized footprint and performance.